### PR TITLE
Fix to allow functions to be used as arg types

### DIFF
--- a/src/argparse_tui/schemas.py
+++ b/src/argparse_tui/schemas.py
@@ -85,7 +85,7 @@ class ArgumentSchema:
                         break
                 else:
                     self.type = default_type
-        elif isinstance(self.type, type):
+        elif isinstance(self.type, type) or callable(self.type):
             self.type = [self.type]
         elif len(self.type) == 1 and isinstance(self.type[0], ChoiceSchema):
             # if there is only one type and it is a 'ChoiceSchema':


### PR DESCRIPTION
If you do something like:

```
parser.add_argument(
            '-e',
            '--email',
            help='Email address',
            type=str.lower
        )
```
Currently, it tries to call `len` on the method `str.lower` which fails. This change handles it.